### PR TITLE
update dependencies for use with more recent versions of node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ssrs",
     "description": "Wrapper around Sql Server reporting service",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "keywords" : ["SQL Server", "reporting service", "reporting"],
     "repository": {
         "type": "git",
@@ -13,8 +13,8 @@
     "dependencies" :
     {
         "comb" : ">=0.1.1",
-        "csv" : "0.0.11",
-        "xml2json" : "0.2.4",
+        "csv" : "0.3.x",
+        "xml2json" : "0.3.x",
         "request" : "2.9.153"
     },
     "devDependencies" :


### PR DESCRIPTION
In particular xml2json v0.2.4 relied on node-expat 1.4.1 which fails to install properly
